### PR TITLE
Add FastAPI skeleton exposing audio-analysis endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, UploadFile, File
+from tools import analyze_audio
+import tempfile
+import os
+
+app = FastAPI(title="Producer's Copilot API")
+
+@app.post("/analyze")
+async def analyze_audio_endpoint(file: UploadFile = File(...)):
+    """Analyze an uploaded audio file and return DSP metrics."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=file.filename) as tmp:
+        tmp.write(await file.read())
+        tmp_path = tmp.name
+    try:
+        metrics = analyze_audio(tmp_path)
+    finally:
+        os.unlink(tmp_path)
+    return metrics
+
+@app.post("/references")
+async def add_reference_endpoint(file: UploadFile = File(...)):
+    """Store a reference track embedding in the vector database (placeholder)."""
+    return {"message": "add_reference not yet implemented"}
+
+@app.get("/references")
+async def list_references_endpoint():
+    """List stored reference tracks (placeholder)."""
+    return {"references": []}
+
+@app.post("/tips")
+async def production_tips_endpoint(file: UploadFile = File(...)):
+    """Generate production tips for an uploaded track (placeholder)."""
+    return {"tips": []}


### PR DESCRIPTION
## Summary
- add `api.py` with a FastAPI app exposing analysis and placeholder endpoints

## Testing
- `python -m py_compile api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1b173bd0c8332aea10c6173f4ca84